### PR TITLE
Add type annotation to SignedHash model

### DIFF
--- a/authsign/__init__.py
+++ b/authsign/__init__.py
@@ -1,3 +1,3 @@
 """ authsign package """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/authsign/acme_signer.py
+++ b/authsign/acme_signer.py
@@ -85,6 +85,7 @@ class AcmeSigner:
                 if isinstance(i.chall, challenges.HTTP01):
                     return i
 
+        # pylint: disable=broad-exception-raised
         raise Exception("HTTP-01 challenge was not offered by the CA server.")
 
     @contextmanager

--- a/authsign/model.py
+++ b/authsign/model.py
@@ -1,6 +1,6 @@
 """ Models for api """
 
-from typing import Optional
+from typing import Optional, ClassVar
 from datetime import datetime
 
 from pydantic import BaseModel, validator
@@ -30,7 +30,7 @@ class SignReq(BaseModel):
 class SignedHash(SignReq):
     """Signed Hash of the SignReq, created by signer, ready for verification"""
 
-    version = "0.1.0"
+    version: ClassVar[str] = "0.1.0"
 
     software: Optional[str]
 

--- a/authsign/model.py
+++ b/authsign/model.py
@@ -1,6 +1,6 @@
 """ Models for api """
 
-from typing import Optional, ClassVar
+from typing import Optional
 from datetime import datetime
 
 from pydantic import BaseModel, validator
@@ -30,7 +30,7 @@ class SignReq(BaseModel):
 class SignedHash(SignReq):
     """Signed Hash of the SignReq, created by signer, ready for verification"""
 
-    version: ClassVar[str] = "0.1.0"
+    version: str = "0.1.0"
 
     software: Optional[str]
 

--- a/authsign/signer.py
+++ b/authsign/signer.py
@@ -193,6 +193,7 @@ class Signer:
             self.update_signing_key_and_cert()
 
         if not self.domain_signing:
+            # pylint: disable=broad-exception-raised
             raise Exception("Could not load domain signing cert + keys")
 
         self.timestampers = [Timestamper(**ts_data) for ts_data in timestamping]
@@ -312,6 +313,7 @@ class Signer:
                 timestamp - self.stamp_duration, timestamp, created
             )
             print(msg)
+            # pylint: disable=broad-exception-raised
             raise Exception(msg)
 
         return SignedHash(

--- a/authsign/signer.py
+++ b/authsign/signer.py
@@ -1,6 +1,7 @@
 """
 Generate or load certs and handle signing
 """
+
 from pathlib import Path
 
 import datetime

--- a/authsign/utils.py
+++ b/authsign/utils.py
@@ -44,6 +44,7 @@ def format_date(date):
 @contextlib.contextmanager
 def open_file(filename_or_resource, mode):
     """open file from either package or file system"""
+    # pylint: disable=deprecated-method
     res = None
     if filename_or_resource.startswith("pkg://"):
         pkg, resource = filename_or_resource[6:].split("/", 1)

--- a/authsign/verifier.py
+++ b/authsign/verifier.py
@@ -1,6 +1,5 @@
 """ Verify signed responses api"""
 
-
 import base64
 import traceback
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 cryptography
 rfc3161ng
 pem
-fastapi==0.86.0
+fastapi
 uvicorn
 pyyaml
 acme
 pyasn1
 python-dateutil
 pydantic==1.10.13
+httpx>=0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pyasn1
 python-dateutil
 pydantic==1.10.13
 httpx>=0.22.0
+h11<0.13,>=0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyyaml
 acme
 pyasn1
 python-dateutil
+pydantic==1.10.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cryptography
 rfc3161ng
 pem
-fastapi
+fastapi==0.86.0
 uvicorn
 pyyaml
 acme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cryptography
 rfc3161ng
 pem
-fastapi
+fastapi==0.110.1
 uvicorn
 pyyaml
 acme

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ acme
 pyasn1
 python-dateutil
 pydantic==1.10.13
-httpx>=0.22.0
+httpx>=0.22.0,<1.0
 h11<0.13,>=0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ pyasn1
 python-dateutil
 pydantic==1.10.13
 httpx>=0.22.0,<1.0
-h11<0.13,>=0.11
+h11<0.15,>=0.13

--- a/tests/test_authsign.py
+++ b/tests/test_authsign.py
@@ -134,7 +134,7 @@ def test_sign_invalid_token(domain, config_file):
     req = {"hash": "some_data", "created": now}
 
     with TestClient(app) as client:
-        resp = client.request("POST", "/sign", data=req)
+        resp = client.request("POST", "/sign", json=req)
         assert resp.status_code == 403
 
         resp = client.request(
@@ -143,7 +143,7 @@ def test_sign_invalid_token(domain, config_file):
             headers={
                 "Authorization": "bearer " + base64.b64encode(b"abc").decode("ascii")
             },
-            data=req,
+            json=req,
         )
         assert resp.status_code == 403
 

--- a/tests/test_authsign.py
+++ b/tests/test_authsign.py
@@ -155,7 +155,7 @@ def test_sign_valid_token(domain, config_file):
     global signed_hash
     with TestClient(app) as client:
         resp = client.request(
-            "POST", "/sign", headers={"Authorization": "bearer " + auth_token}, data=req
+            "POST", "/sign", headers={"Authorization": "bearer " + auth_token}, json=req
         )
         signed_hash = resp.json()
         print(signed_hash)
@@ -191,7 +191,7 @@ def test_sign_valid_token_a_few_mins_ago(domain, config_file):
 
     with TestClient(app) as client:
         resp = client.request(
-            "POST", "/sign", headers={"Authorization": "bearer " + auth_token}, data=req
+            "POST", "/sign", headers={"Authorization": "bearer " + auth_token}, json=req
         )
         assert resp.status_code == 200
 
@@ -207,7 +207,7 @@ def test_sign_valid_token_wrong_date_too_early(domain, config_file):
     global signed_hash
     with TestClient(app) as client:
         resp = client.request(
-            "POST", "/sign", headers={"Authorization": "bearer " + auth_token}, data=req
+            "POST", "/sign", headers={"Authorization": "bearer " + auth_token}, json=req
         )
         assert resp.status_code == 400
 
@@ -223,7 +223,7 @@ def test_sign_valid_token_bad_date_in_future(domain, config_file):
     global signed_hash
     with TestClient(app) as client:
         resp = client.request(
-            "POST", "/sign", headers={"Authorization": "bearer " + auth_token}, data=req
+            "POST", "/sign", headers={"Authorization": "bearer " + auth_token}, json=req
         )
         assert resp.status_code == 400
 
@@ -232,7 +232,7 @@ def test_verify_invalid_missing(domain, config_file):
     with TestClient(app) as client:
         req = signed_hash.copy()
         req.pop("timeSignature", "")
-        resp = client.request("POST", "/verify", data=req)
+        resp = client.request("POST", "/verify", json=req)
         assert resp.status_code == 422
 
 
@@ -240,7 +240,7 @@ def test_verify_invalid_hash(domain, config_file):
     with TestClient(app) as client:
         req = signed_hash.copy()
         req["hash"] = "other data"
-        resp = client.request("POST", "/verify", data=req)
+        resp = client.request("POST", "/verify", json=req)
         assert resp.status_code == 400
 
 
@@ -248,7 +248,7 @@ def test_verify_wrong_cert(domain, config_file):
     with TestClient(app) as client:
         req = signed_hash.copy()
         req["timestampCert"] = req["domainCert"]
-        resp = client.request("POST", "/verify", data=req)
+        resp = client.request("POST", "/verify", json=req)
         assert resp.status_code == 400
 
 
@@ -256,7 +256,7 @@ def test_verify_wrong_cross_signed_cert(domain, config_file):
     with TestClient(app) as client:
         req = signed_hash.copy()
         req["crossSignedCert"] = req["timestampCert"]
-        resp = client.request("POST", "/verify", data=req)
+        resp = client.request("POST", "/verify", json=req)
         assert resp.status_code == 400
 
 
@@ -265,7 +265,7 @@ def test_verify_invalid_bad_date(domain, config_file):
         # date to early
         req = signed_hash.copy()
         req["created"] = "abc"
-        resp = client.request("POST", "/verify", data=req)
+        resp = client.request("POST", "/verify", json=req)
         assert resp.status_code == 422
 
 
@@ -276,7 +276,7 @@ def test_verify_invalid_date_out_of_range(domain, config_file):
         req["created"] = format_date(
             datetime.datetime.utcnow() - datetime.timedelta(days=1)
         )
-        resp = client.request("POST", "/verify", data=req)
+        resp = client.request("POST", "/verify", json=req)
         assert resp.status_code == 400
 
         # date to late
@@ -284,13 +284,13 @@ def test_verify_invalid_date_out_of_range(domain, config_file):
         req["created"] = format_date(
             datetime.datetime.utcnow() + datetime.timedelta(days=1)
         )
-        resp = client.request("POST", "/verify", data=req)
+        resp = client.request("POST", "/verify", json=req)
         assert resp.status_code == 400
 
 
 def test_verify_valid(domain, config_file):
     with TestClient(app) as client:
-        resp = client.request("POST", "/verify", data=signed_hash)
+        resp = client.request("POST", "/verify", json=signed_hash)
         assert resp.status_code == 200
         res = resp.json()
         assert res["observer"] == domain

--- a/tests/test_authsign.py
+++ b/tests/test_authsign.py
@@ -134,15 +134,16 @@ def test_sign_invalid_token(domain, config_file):
     req = {"hash": "some_data", "created": now}
 
     with TestClient(app) as client:
-        resp = client.post("/sign", json=req)
+        resp = client.request("POST", "/sign", data=req)
         assert resp.status_code == 403
 
-        resp = client.post(
+        resp = client.request(
+            "POST",
             "/sign",
             headers={
                 "Authorization": "bearer " + base64.b64encode(b"abc").decode("ascii")
             },
-            json=req,
+            data=req,
         )
         assert resp.status_code == 403
 
@@ -153,8 +154,8 @@ def test_sign_valid_token(domain, config_file):
 
     global signed_hash
     with TestClient(app) as client:
-        resp = client.post(
-            "/sign", headers={"Authorization": "bearer " + auth_token}, json=req
+        resp = client.request(
+            "POST", "/sign", headers={"Authorization": "bearer " + auth_token}, data=req
         )
         signed_hash = resp.json()
         print(signed_hash)
@@ -189,8 +190,8 @@ def test_sign_valid_token_a_few_mins_ago(domain, config_file):
     req = {"hash": "some_data", "created": now}
 
     with TestClient(app) as client:
-        resp = client.post(
-            "/sign", headers={"Authorization": "bearer " + auth_token}, json=req
+        resp = client.request(
+            "POST", "/sign", headers={"Authorization": "bearer " + auth_token}, data=req
         )
         assert resp.status_code == 200
 
@@ -205,8 +206,8 @@ def test_sign_valid_token_wrong_date_too_early(domain, config_file):
 
     global signed_hash
     with TestClient(app) as client:
-        resp = client.post(
-            "/sign", headers={"Authorization": "bearer " + auth_token}, json=req
+        resp = client.request(
+            "POST", "/sign", headers={"Authorization": "bearer " + auth_token}, data=req
         )
         assert resp.status_code == 400
 
@@ -221,8 +222,8 @@ def test_sign_valid_token_bad_date_in_future(domain, config_file):
 
     global signed_hash
     with TestClient(app) as client:
-        resp = client.post(
-            "/sign", headers={"Authorization": "bearer " + auth_token}, json=req
+        resp = client.request(
+            "POST", "/sign", headers={"Authorization": "bearer " + auth_token}, data=req
         )
         assert resp.status_code == 400
 
@@ -231,7 +232,7 @@ def test_verify_invalid_missing(domain, config_file):
     with TestClient(app) as client:
         req = signed_hash.copy()
         req.pop("timeSignature", "")
-        resp = client.post("/verify", json=req)
+        resp = client.request("POST", "/verify", data=req)
         assert resp.status_code == 422
 
 
@@ -239,7 +240,7 @@ def test_verify_invalid_hash(domain, config_file):
     with TestClient(app) as client:
         req = signed_hash.copy()
         req["hash"] = "other data"
-        resp = client.post("/verify", json=req)
+        resp = client.request("POST", "/verify", data=req)
         assert resp.status_code == 400
 
 
@@ -247,7 +248,7 @@ def test_verify_wrong_cert(domain, config_file):
     with TestClient(app) as client:
         req = signed_hash.copy()
         req["timestampCert"] = req["domainCert"]
-        resp = client.post("/verify", json=req)
+        resp = client.request("POST", "/verify", data=req)
         assert resp.status_code == 400
 
 
@@ -255,7 +256,7 @@ def test_verify_wrong_cross_signed_cert(domain, config_file):
     with TestClient(app) as client:
         req = signed_hash.copy()
         req["crossSignedCert"] = req["timestampCert"]
-        resp = client.post("/verify", json=req)
+        resp = client.request("POST", "/verify", data=req)
         assert resp.status_code == 400
 
 
@@ -264,7 +265,7 @@ def test_verify_invalid_bad_date(domain, config_file):
         # date to early
         req = signed_hash.copy()
         req["created"] = "abc"
-        resp = client.post("/verify", json=req)
+        resp = client.request("POST", "/verify", data=req)
         assert resp.status_code == 422
 
 
@@ -275,7 +276,7 @@ def test_verify_invalid_date_out_of_range(domain, config_file):
         req["created"] = format_date(
             datetime.datetime.utcnow() - datetime.timedelta(days=1)
         )
-        resp = client.post("/verify", json=req)
+        resp = client.request("POST", "/verify", data=req)
         assert resp.status_code == 400
 
         # date to late
@@ -283,13 +284,13 @@ def test_verify_invalid_date_out_of_range(domain, config_file):
         req["created"] = format_date(
             datetime.datetime.utcnow() + datetime.timedelta(days=1)
         )
-        resp = client.post("/verify", json=req)
+        resp = client.request("POST", "/verify", data=req)
         assert resp.status_code == 400
 
 
 def test_verify_valid(domain, config_file):
     with TestClient(app) as client:
-        resp = client.post("/verify", json=signed_hash)
+        resp = client.request("POST", "/verify", data=signed_hash)
         assert resp.status_code == 200
         res = resp.json()
         assert res["observer"] == domain


### PR DESCRIPTION
In addition, modify requirements and test TestClient method calls to account for Starlette's change from requests to httpx and re-format code for linting.

Bumps version to 0.5.1 so that we can release this and use it in py-wacz without test failures.