### PR TITLE
timestamp range check: truncate microseconds as rfc3161 timestamp is …

### DIFF
--- a/authsign/__init__.py
+++ b/authsign/__init__.py
@@ -1,3 +1,3 @@
 """ authsign package """
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"

--- a/authsign/signer.py
+++ b/authsign/signer.py
@@ -306,7 +306,8 @@ class Signer:
 
         time_signature, timestamp = timestamper(signature)
 
-        created = sign_req.created
+        # truncate microseconds, as timestamp server rounds down to closest second
+        created = sign_req.created.replace(microsecond=0)
 
         if not no_older_then(created, timestamp, self.stamp_duration):
             msg = "Created timestamp is out of range: Must be between between {0} and {1}, but is {2}".format(
@@ -319,7 +320,7 @@ class Signer:
         return SignedHash(
             software="authsigner " + __version__,
             hash=sign_req.hash,
-            created=created,
+            created=sign_req.created,
             signature=signature,
             timeSignature=time_signature,
             domain=self.domain,


### PR DESCRIPTION
…rounded to seconds,

while request timestamp may have microseconds. just drop microseconds if present on request timestamp 

wacz-signer seems to take a similar approach by adding one second:
https://github.com/harvard-lil/wacz-signing/blob/develop/wacz_signing/signer.py#L335


bump to 0.5.2